### PR TITLE
<fix>: fix the bug of line 8: -m: command not found when run evaluation

### DIFF
--- a/thinking-in-space/eval_vlm_3r_vsibench.sh
+++ b/thinking-in-space/eval_vlm_3r_vsibench.sh
@@ -1,8 +1,9 @@
 export CUDA_VISIBLE_DEVICES=0 # If you have multiple GPUs, you can set the actual GPU IDs, e.g., "0,1,2"
 export LMMS_EVAL_LAUNCHER="accelerate"
 
+# If you have multiple GPUs, you can set --num_processes=the number of GPUs to use
 accelerate launch \
-    --num_processes=1 \ # If you have multiple GPUs, you can set the number of GPUs to use
+    --num_processes=1 \
     -m lmms_eval \
     --model vlm_3r \
     --model_args pretrained=Journey9ni/vlm-3r-llava-qwen2-lora,model_base=lmms-lab/LLaVA-NeXT-Video-7B-Qwen2,conv_template=qwen_1_5,max_frames_num=32 \

--- a/thinking-in-space/eval_vlm_3r_vstibench.sh
+++ b/thinking-in-space/eval_vlm_3r_vstibench.sh
@@ -1,8 +1,9 @@
 export CUDA_VISIBLE_DEVICES=0 # If you have multiple GPUs, you can set the actual GPU IDs, e.g., "0,1,2"
 export LMMS_EVAL_LAUNCHER="accelerate"
 
+# If you have multiple GPUs, you can set --num_processes=the number of GPUs to use
 accelerate launch \
-    --num_processes=1 \ # If you have multiple GPUs, you can set the number of GPUs to use
+    --num_processes=1 \
     -m lmms_eval \
     --model vlm_3r \
     --model_args pretrained=Journey9ni/vlm-3r-llava-qwen2-lora,model_base=lmms-lab/LLaVA-NeXT-Video-7B-Qwen2,conv_template=qwen_1_5,max_frames_num=32 \


### PR DESCRIPTION
Fix the error: eval_vlm_3r_vsibench.sh: line 9: -m: command not found

Reason:
The evaluation script encountered an error because the usage of `\\' in the accelerate launch command is incorrect. In Bash, the backslash (\\) is used to indicate a line continuation, but it cannot be followed by any extra characters, including comments (\#) or spaces. If a comment is placed on the same line as the backslash, Bash will interpret the comment as part of the command, resulting in an error.
