### PR TITLE
Update citation for CVPR 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,13 +318,12 @@ We would like to express our gratitude to the following projects for their valua
 If you find VLM-3R useful for your research, please consider citing our paper:
 
 ```bibtex
-@misc{fan2025vlm3rvisionlanguagemodelsaugmented,
-      title={VLM-3R: Vision-Language Models Augmented with Instruction-Aligned 3D Reconstruction}, 
-      author={Zhiwen Fan and Jian Zhang and Renjie Li and Junge Zhang and Runjin Chen and Hezhen Hu and Kevin Wang and Huaizhi Qu and Shijie Zhou and Dilin Wang and Zhicheng Yan and Hongyu Xu and Justin Theiss and Tianlong Chen and Jiachen Li and Zhengzhong Tu and Zhangyang Wang and Rakesh Ranjan},
-      year={2025},
-      eprint={2505.20279},
-      archivePrefix={arXiv},
-      primaryClass={cs.CV},
-      url={https://arxiv.org/abs/2505.20279}, 
+@InProceedings{Fan_2026_CVPR,
+    author    = {Fan, Zhiwen and Zhang, Jian and Li, Renjie and Zhang, Junge and Chen, Runjin and Hu, Hezhen and Wang, Kevin and Wang, Peihao and Qu, Huaizhi and Zhou, Shijie and Wang, Dilin and Yan, Zhicheng and Xu, Hongyu and Theiss, Justin and Chen, Tianlong and Li, Jiachen and Tu, Zhengzhong and Wang, Zhangyang and Ranjan, Rakesh},
+    title     = {VLM-3R: Vision-Language Models Augmented with Instruction-Aligned 3D Reconstruction},
+    booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+    month     = {June},
+    year      = {2026},
+    pages     = {31054--31065}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -318,12 +318,11 @@ We would like to express our gratitude to the following projects for their valua
 If you find VLM-3R useful for your research, please consider citing our paper:
 
 ```bibtex
-@InProceedings{fan2026vlm3r,
-    author    = {Fan, Zhiwen and Zhang, Jian and Li, Renjie and Zhang, Junge and Chen, Runjin and Hu, Hezhen and Wang, Kevin and Wang, Peihao and Qu, Huaizhi and Zhou, Shijie and Wang, Dilin and Yan, Zhicheng and Xu, Hongyu and Theiss, Justin and Chen, Tianlong and Li, Jiachen and Tu, Zhengzhong and Wang, Zhangyang and Ranjan, Rakesh},
-    title     = {VLM-3R: Vision-Language Models Augmented with Instruction-Aligned 3D Reconstruction},
-    booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
-    month     = {June},
-    year      = {2026},
-    pages     = {31054--31065}
+@inproceedings{fan2026vlm3r,
+  title={VLM-3R: Vision-Language Models Augmented with Instruction-Aligned 3D Reconstruction},
+  author={Fan, Zhiwen and Zhang, Jian and Li, Renjie and Zhang, Junge and Chen, Runjin and Hu, Hezhen and Wang, Kevin and Wang, Peihao and Qu, Huaizhi and Zhou, Shijie and Wang, Dilin and Yan, Zhicheng and Xu, Hongyu and Theiss, Justin and Chen, Tianlong and Li, Jiachen and Tu, Zhengzhong and Wang, Zhangyang and Ranjan, Rakesh},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition},
+  pages={31054--31065},
+  year={2026}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ We would like to express our gratitude to the following projects for their valua
 If you find VLM-3R useful for your research, please consider citing our paper:
 
 ```bibtex
-@InProceedings{Fan_2026_CVPR,
+@InProceedings{fan2026vlm3r,
     author    = {Fan, Zhiwen and Zhang, Jian and Li, Renjie and Zhang, Junge and Chen, Runjin and Hu, Hezhen and Wang, Kevin and Wang, Peihao and Qu, Huaizhi and Zhou, Shijie and Wang, Dilin and Yan, Zhicheng and Xu, Hongyu and Theiss, Justin and Chen, Tianlong and Li, Jiachen and Tu, Zhengzhong and Wang, Zhangyang and Ranjan, Rakesh},
     title     = {VLM-3R: Vision-Language Models Augmented with Instruction-Aligned 3D Reconstruction},
     booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},


### PR DESCRIPTION
## What changed

- Replace the arXiv BibTeX entry with the CVPR 2026 proceedings citation.
- Follow Google Scholar's field order and formatting: title, author, booktitle, pages, and year.
- Add the official page range (31054–31065).
- Include Peihao Wang in the author list.
- Keep the paper entry at the top of the README linked to arXiv.

## Why

The paper has appeared in the CVPR 2026 proceedings, so readers should cite the published conference version instead of the arXiv preprint.

## Impact

Documentation only; no code or runtime behavior changes.

## Validation

- Cross-checked the publication details against the CVF Open Access record.
- Matched the BibTeX structure used by Google Scholar.
- Ran `git diff --check`.